### PR TITLE
Add spec and method for game creation.

### DIFF
--- a/app/controllers/api/v1/games_controller.rb
+++ b/app/controllers/api/v1/games_controller.rb
@@ -6,4 +6,15 @@ class Api::V1::GamesController < ApplicationController
   def show
     render json: GameSerializer.new(Game.high_score(params[:user_id]))
   end
+
+  def create
+    require "pry"; binding.pry
+    Game.create(game_params)
+  end
+
+  private
+
+  def game_params
+    params.require(:game).permit(:user_id, :score, :city, :state, :country, :game_time)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
 
       resources :questions, only: :index
 
-      resources :games, only: [:show, :index]
+      resources :games, only: [:show, :index, :create]
 
     end
   end

--- a/spec/requests/api/v1/questions_request_spec.rb
+++ b/spec/requests/api/v1/questions_request_spec.rb
@@ -22,4 +22,21 @@ RSpec.describe 'Questions Index' do
       expect(question[:attributes][:answers]).to be_a(Array)
     end
   end
+
+  it 'can create a new game' do
+    game_params = {user_id: 7, score: 1000, city: "Las Vegas", state: "NV", country: "USA", game_time: 5.30}
+    headers = {"CONTENT_TYPE" => "application/json"}
+
+    post '/api/v1/games', headers: headers, params: JSON.generate(game: game_params)
+
+    created_game = Game.last
+
+    expect(response).to be_successful
+    expect(created_game.user_id).to eq(game_params[:user_id])
+    expect(created_game.score).to eq(game_params[:score])
+    expect(created_game.city).to eq(game_params[:city])
+    expect(created_game.state).to eq(game_params[:state])
+    expect(created_game.country).to eq(game_params[:country])
+    expect(created_game.game_time).to eq(game_params[:game_time])
+  end
 end


### PR DESCRIPTION
Adds POST endpoint to record a new game to the database.

POST '/api/v1/games'

I think Sam was right earlier. We should rename the games controller to scores controller. It's a bit more indicative of what we're finding and saving to the database. When we get our new teams tomorrow we can start to switch it over.