### PR TITLE
Combine score searches

### DIFF
--- a/app/controllers/api/v1/scores_controller.rb
+++ b/app/controllers/api/v1/scores_controller.rb
@@ -1,11 +1,12 @@
 class Api::V1::ScoresController < ApplicationController
   def index
-    render json: ScoreSerializer.new(Score.top_scores_by_location(params[:geo_scope], params[:user_location]))
+    # render json: ScoreSerializer.new(Score.top_scores_by_location(params[:geo_scope], params[:user_location]))
+    render json: ScoreSerializer.new(Score.top_5_highest_scores(params))
   end
 
-  def show
-    render json: ScoreSerializer.new(Score.high_score(params[:user_id]))
-  end
+  # def show
+  #   render json: ScoreSerializer.new(Score.high_score(params[:user_id]))
+  # end
 
   def create
     Score.create(score_params)

--- a/app/models/score.rb
+++ b/app/models/score.rb
@@ -1,10 +1,21 @@
 class Score < ApplicationRecord
 
-  def self.high_score(user)
-    where(user_id: user).order(score: :desc).first
-  end
-  
-  def self.top_scores_by_location(geo_scope, user_location)
-    Score.where("#{geo_scope} = '#{user_location}'").order(score: :desc).limit(5)
+  # def self.high_score(user)
+  #   where(user_id: user).order(score: :desc).first
+  # end
+  #
+  # def self.top_scores_by_location(geo_scope, user_location)
+  #   where("#{geo_scope} = '#{user_location}'").order(score: :desc).limit(5)
+  # end
+
+  def self.top_5_highest_scores(params)
+    # require "pry"; binding.pry
+    if params.has_key?(:geo_scope)
+      where("#{params[:geo_scope]} = '#{params[:user_location]}'").order(score: :desc).limit(5)
+    elsif params.has_key?(:user_id)
+      where(user_id: params[:user_id]).order(score: :desc).limit(5)
+    else
+      order(score: :desc).limit(5)
+    end
   end
 end

--- a/app/models/score.rb
+++ b/app/models/score.rb
@@ -9,7 +9,6 @@ class Score < ApplicationRecord
   # end
 
   def self.top_5_highest_scores(params)
-    # require "pry"; binding.pry
     if params.has_key?(:geo_scope)
       where("#{params[:geo_scope]} = '#{params[:user_location]}'").order(score: :desc).limit(5)
     elsif params.has_key?(:user_id)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
 
       resources :questions, only: :index
 
-      resources :scores, only: %i[show index create]
+      resources :scores, only: %i[index create]
 
     end
   end

--- a/spec/models/score_spec.rb
+++ b/spec/models/score_spec.rb
@@ -36,11 +36,17 @@ RSpec.describe Score do
 
   describe 'methods' do
     it 'can find top score by user' do
-      expect(Score.high_score(@user_id)).to eq(@score_1)
+      scores_by_player_id = Score.top_5_highest_scores({user_id: @user_id})
+
+      expect(scores_by_player_id).to eq([@score_1, @score_2])
     end
 
     it 'can find top score by city' do
-      expect(Score.top_scores_by_location("city", "Denver")).to eq([@score_1, @score_3, @score_2])
+      scores_by_city = Score.top_5_highest_scores({geo_scope: "city", user_location: 'Denver'})
+      expected = scores_by_city.map do |score|
+        score
+      end
+      expect(expected).to eq([@score_1, @score_3, @score_2])
     end
   end
 end

--- a/spec/requests/api/v1/scores_request_spec.rb
+++ b/spec/requests/api/v1/scores_request_spec.rb
@@ -114,7 +114,6 @@ RSpec.describe "Scores Index" do
      expect(response).to be_successful
 
      score = JSON.parse(response.body, symbolize_names: true)
-     # require "pry"; binding.pry
 
      expect(score[:data]).to be_a(Array)
      score[:data].each do |s|

--- a/spec/requests/api/v1/scores_request_spec.rb
+++ b/spec/requests/api/v1/scores_request_spec.rb
@@ -109,23 +109,25 @@ RSpec.describe "Scores Index" do
   it "can send the highest score by user id" do
      high_score = Score.create!(user_id: 15, score: 100, city: 'Chicago', state: 'Illinois', country: 'United States')
 
-     get "/api/v1/scores/#{high_score.id}", params:{user_id: high_score.user_id}
+     get "/api/v1/scores", params:{user_id: high_score.user_id}
 
      expect(response).to be_successful
 
      score = JSON.parse(response.body, symbolize_names: true)
+     # require "pry"; binding.pry
 
-     expect(score[:data]).to be_a(Hash)
-     expect(score[:data]).to have_key(:id)
-     expect(score[:data]).to have_key(:type)
-     expect(score[:data]).to have_key(:attributes)
-     expect(score[:data][:attributes]).to have_key(:score)
-     expect(score[:data][:attributes][:score]).to eq(high_score.score)
-     expect(score[:data][:attributes]).to have_key(:game_time)
-     expect(score[:data][:attributes]).to have_key(:user_id)
-     expect(score[:data][:attributes]).to have_key(:city)
-     expect(score[:data][:attributes]).to have_key(:state)
-     expect(score[:data][:attributes]).to have_key(:country)
+     expect(score[:data]).to be_a(Array)
+     score[:data].each do |s|
+       expect(s).to have_key(:id)
+       expect(s).to have_key(:type)
+       expect(s).to have_key(:attributes)
+       expect(s[:attributes]).to have_key(:score)
+       expect(s[:attributes][:score]).to eq(high_score.score)
+       expect(s[:attributes]).to have_key(:user_id)
+       expect(s[:attributes]).to have_key(:city)
+       expect(s[:attributes]).to have_key(:state)
+       expect(s[:attributes]).to have_key(:country)
+     end
   end
 
   it 'can create a new score', :vcr do


### PR DESCRIPTION
I wrote a new method that examines the params and returns the top 5 scores for location or user. This makes the routing a little more restful and moves all of the search functionality to the index. 
I think this is the best move, because we're returning a collection of scores, whether it's user or location. 

This also includes an else statement if we want to move forward with a world element.  If there isn't a :geo_scope or :user_id param, then it returns the top 5 overall scores.