### PR TITLE
Randomize questions

### DIFF
--- a/app/facades/questions_facade.rb
+++ b/app/facades/questions_facade.rb
@@ -1,7 +1,7 @@
 class QuestionsFacade
   def self.trivia
     id = 0
-    questions = QuestionsService.trivia[:results].map do |t|
+    QuestionsService.trivia[:results].map do |t|
       id += 1
       t[:id] = "#{id}"
       Question.new(t)

--- a/app/facades/questions_facade.rb
+++ b/app/facades/questions_facade.rb
@@ -1,10 +1,10 @@
 class QuestionsFacade
   def self.trivia
     id = 0
-    QuestionsService.trivia[:results].map do |t|
+    questions = QuestionsService.trivia[:results].map do |t|
       id += 1
       t[:id] = "#{id}"
       Question.new(t)
-    end
+    end.shuffle![0..4]
   end
 end

--- a/spec/requests/api/v1/question_request_spec.rb
+++ b/spec/requests/api/v1/question_request_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe 'Questions Index' do
     expect(response).to be_successful
 
     questions = JSON.parse(response.body, symbolize_names: true)
-
-    expect(questions[:data].count).to eq(50)
+    
+    expect(questions[:data].count).to eq(5)
     questions[:data].each do |question|
       expect(question[:attributes]).to have_key(:id)
       expect(question[:attributes][:id]).to be_a(String)


### PR DESCRIPTION
Adds shuffle method to questions facade to pull random assortment of trivia questions.

Also returns only 5 results to limit load on front end.